### PR TITLE
Use an older version of eosjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "eosjs": "^6.1.8",
+    "eosjs": "6.1.6",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-scripts": "1.1.1"


### PR DESCRIPTION
The newer version of eosjs wouldn't compile successfully during the create-react-app 'npm run build'